### PR TITLE
avoid transforming side effecty member expression checks[fix #469]

### DIFF
--- a/packages/babel-plugin-minify-guarded-expressions/__tests__/guarded-expressions-test.js
+++ b/packages/babel-plugin-minify-guarded-expressions/__tests__/guarded-expressions-test.js
@@ -178,4 +178,16 @@ describe("guarded-expressions-plugin", () => {
     );
     expect(transform(source)).toBe(source);
   });
+
+  it("should not minify side effecty member expression checks", () => {
+    let source = unpad(
+      `
+      {
+        var a = {};
+      }
+      var b = a && a[foo];
+    `
+    );
+    expect(transform(source)).toBe(source);
+  });
 });


### PR DESCRIPTION
+ this transform happens on simplify as well.. So the issue itself is not resolved. 

fix #469

Just keeping it here so that we can remove it from one place and apply this fix. 