### PR TITLE
Disable property litterals package by default

### DIFF
--- a/packages/babel-preset-babili/src/index.js
+++ b/packages/babel-preset-babili/src/index.js
@@ -19,7 +19,7 @@ const PLUGINS = [
   ["memberExpressions",   require("babel-plugin-transform-member-expression-literals"),    true],
   ["mergeVars",           require("babel-plugin-transform-merge-sibling-variables"),       true],
   ["numericLiterals",     require("babel-plugin-minify-numeric-literals"),                 true],
-  ["propertyLiterals",    require("babel-plugin-transform-property-literals"),             true],
+  ["propertyLiterals",    require("babel-plugin-transform-property-literals"),             false],
   ["regexpConstructors",  require("babel-plugin-transform-regexp-constructors"),           true],
   ["removeConsole",       require("babel-plugin-transform-remove-console"),                false],
   ["removeDebugger",      require("babel-plugin-transform-remove-debugger"),               false],


### PR DESCRIPTION
I'm suggesting to disable the `babel-plugin-transform-property-literals` by default as it is not working correctly in ES5.

I was intending to write a failing unit test, but it turns out that there is already a test that is demonstrating a bad behaviour

https://github.com/babel/babili/blob/master/packages/babel-plugin-transform-property-literals/__tests__/transform-property-literals-test.js#L39