### PR TITLE
Add exclude option for transform-remove-console plugin

### DIFF
--- a/packages/babel-plugin-transform-remove-console/README.md
+++ b/packages/babel-plugin-transform-remove-console/README.md
@@ -29,8 +29,16 @@ npm install babel-plugin-transform-remove-console
 **.babelrc**
 
 ```json
+// without options
 {
   "plugins": ["transform-remove-console"]
+}
+```
+
+```json
+// with options
+{
+  "plugins": ["transform-remove-console": { "exclude": [ "error", "warn"] }]
 }
 ```
 
@@ -47,3 +55,7 @@ require("babel-core").transform("code", {
   plugins: ["transform-remove-console"]
 });
 ```
+
+## Options
+
++ `exclude` - An array of console methods to exclude from removal.

--- a/packages/babel-plugin-transform-remove-console/README.md
+++ b/packages/babel-plugin-transform-remove-console/README.md
@@ -38,7 +38,7 @@ npm install babel-plugin-transform-remove-console
 ```json
 // with options
 {
-  "plugins": ["transform-remove-console", { "exclude": [ "error", "warn"] }]
+  "plugins": [ ["transform-remove-console", { "exclude": [ "error", "warn"] }] ]
 }
 ```
 

--- a/packages/babel-plugin-transform-remove-console/README.md
+++ b/packages/babel-plugin-transform-remove-console/README.md
@@ -38,7 +38,7 @@ npm install babel-plugin-transform-remove-console
 ```json
 // with options
 {
-  "plugins": ["transform-remove-console": { "exclude": [ "error", "warn"] }]
+  "plugins": ["transform-remove-console", { "exclude": [ "error", "warn"] }]
 }
 ```
 

--- a/packages/babel-plugin-transform-remove-console/__tests__/remove-console-test.js
+++ b/packages/babel-plugin-transform-remove-console/__tests__/remove-console-test.js
@@ -166,7 +166,7 @@ describe("remove-console-plugin with exclude argument", () => {
       console.info("blah");
     }
   `,
-  options
+    options
   );
   thePlugin(
     "should not remove bound excluded options",

--- a/packages/babel-plugin-transform-remove-console/__tests__/remove-console-test.js
+++ b/packages/babel-plugin-transform-remove-console/__tests__/remove-console-test.js
@@ -1,8 +1,6 @@
 jest.autoMockOff();
 
-const babel = require("babel-core");
 const plugin = require("../src/index");
-const unpad = require("../../../utils/unpad");
 const thePlugin = require("../../../utils/test-transform")(plugin);
 
 describe("remove-console-plugin", () => {
@@ -146,64 +144,50 @@ describe("remove-console-plugin", () => {
   );
 });
 
-describe("remove-console-plugin with excludes argument", () => {
+describe("remove-console-plugin with exclude argument", () => {
   const options = {
-    exclude: ["error", "info"]
+    plugins: [[plugin, { exclude: ["error", "info"] }]]
   };
 
-  it("should not remove excluded options", () => {
-    const source = unpad(
-      `
-      function foo() {
-        console.log("foo");
-        console.error("bar");
-        blah();
-        console.info("blah");
-      }
+  thePlugin(
+    "should not remove excluded options",
     `
-    );
-    const output = unpad(
-      `
-      function foo() {
-        console.error("bar");
-        blah();
-        console.info("blah");
-      }
+    function foo() {
+      console.log("foo");
+      console.error("bar");
+      blah();
+      console.info("blah");
+    }
+  `,
     `
-    );
-    expect(
-      babel.transform(source, {
-        plugins: [[plugin, options]]
-      }).code
-    ).toBe(output);
-  });
-  it("should not remove bound excluded options", () => {
-    const source = unpad(
-      `
-      function foo() {
-        const a = console.log;
-        a();
-        const b = console.error.bind(console);
-        b("asdf");
-        blah();
-      }
+    function foo() {
+      console.error("bar");
+      blah();
+      console.info("blah");
+    }
+  `,
+  options
+  );
+  thePlugin(
+    "should not remove bound excluded options",
     `
-    );
-    const output = unpad(
-      `
-      function foo() {
-        const a = function () {};
-        a();
-        const b = console.error.bind(console);
-        b("asdf");
-        blah();
-      }
+    function foo() {
+      const a = console.log;
+      a();
+      const b = console.error.bind(console);
+      b("asdf");
+      blah();
+    }
+  `,
     `
-    );
-    expect(
-      babel.transform(source, {
-        plugins: [[plugin, options]]
-      }).code
-    ).toBe(output);
-  });
+    function foo() {
+      const a = function () {};
+      a();
+      const b = console.error.bind(console);
+      b("asdf");
+      blah();
+    }
+    `,
+    options
+  );
 });

--- a/packages/babel-plugin-transform-remove-console/src/index.js
+++ b/packages/babel-plugin-transform-remove-console/src/index.js
@@ -4,26 +4,29 @@ module.exports = function({ types: t }) {
   return {
     name: "transform-remove-console",
     visitor: {
-      CallExpression(path) {
+      CallExpression(path, state) {
         const callee = path.get("callee");
 
         if (!callee.isMemberExpression()) return;
 
-        if (isConsole(callee)) {
+        if (isIncludedConsole(callee, state)) {
           // console.log()
           if (path.parentPath.isExpressionStatement()) {
             path.remove();
           } else {
             path.replaceWith(createVoid0());
           }
-        } else if (isConsoleBind(callee)) {
+        } else if (isIncludedConsoleBind(callee, state)) {
           // console.log.bind()
           path.replaceWith(createNoop());
         }
       },
       MemberExpression: {
-        exit(path) {
-          if (isConsole(path) && !path.parentPath.isMemberExpression()) {
+        exit(path, state) {
+          if (
+            isIncludedConsole(path, state) &&
+            !path.parentPath.isMemberExpression()
+          ) {
             if (
               path.parentPath.isAssignmentExpression() &&
               path.parentKey === "left"
@@ -47,11 +50,26 @@ module.exports = function({ types: t }) {
     );
   }
 
-  function isConsole(memberExpr) {
+  function isExcluded(property, state) {
+    let exclude = false;
+    if (state.opts.exclude) {
+      state.opts.exclude.forEach(excluded => {
+        if (property.isIdentifier({ name: excluded })) {
+          exclude = true;
+        }
+      });
+    }
+    return exclude;
+  }
+
+  function isIncludedConsole(memberExpr, state) {
     const object = memberExpr.get("object");
+    const property = memberExpr.get("property");
+
+    if (isExcluded(property, state)) return false;
+
     if (isGlobalConsoleId(object)) return true;
 
-    const property = memberExpr.get("property");
     return (
       isGlobalConsoleId(object.get("object")) &&
       (property.isIdentifier({ name: "call" }) ||
@@ -59,10 +77,13 @@ module.exports = function({ types: t }) {
     );
   }
 
-  function isConsoleBind(memberExpr) {
+  function isIncludedConsoleBind(memberExpr, state) {
     const object = memberExpr.get("object");
+
+    if (!object.isMemberExpression()) return false;
+    if (isExcluded(object.get("property"), state)) return false;
+
     return (
-      object.isMemberExpression() &&
       isGlobalConsoleId(object.get("object")) &&
       memberExpr.get("property").isIdentifier({ name: "bind" })
     );

--- a/packages/babel-plugin-transform-remove-console/src/index.js
+++ b/packages/babel-plugin-transform-remove-console/src/index.js
@@ -51,7 +51,9 @@ module.exports = function({ types: t }) {
   }
 
   function isExcluded(property, excludeArray) {
-    return excludeArray && excludeArray.some(name => property.isIdentifier({ name }));
+    return (
+      excludeArray && excludeArray.some(name => property.isIdentifier({ name }))
+    );
   }
 
   function isIncludedConsole(memberExpr, excludeArray) {

--- a/packages/babel-plugin-transform-remove-console/src/index.js
+++ b/packages/babel-plugin-transform-remove-console/src/index.js
@@ -51,15 +51,7 @@ module.exports = function({ types: t }) {
   }
 
   function isExcluded(property, excludeArray) {
-    let exclude = false;
-    if (excludeArray) {
-      excludeArray.forEach(excluded => {
-        if (property.isIdentifier({ name: excluded })) {
-          exclude = true;
-        }
-      });
-    }
-    return exclude;
+    return excludeArray && excludeArray.some(name => property.isIdentifier({ name }));
   }
 
   function isIncludedConsole(memberExpr, excludeArray) {


### PR DESCRIPTION
An attempt to implement the extension requested in https://github.com/babel/minify/issues/598

Based on the unit tests I added, I believe this is working, however as this is my very first attempt at code within the babel ecosystem it is highly likely there are better ways to approach this. I welcome any and all feedback on how to improve this either functionally or idiomatically.