### PR TITLE
add transform-hoist-loose-functions plugin

### DIFF
--- a/packages/babel-plugin-transform-hoist-loose-functions/.npmignore
+++ b/packages/babel-plugin-transform-hoist-loose-functions/.npmignore
@@ -1,0 +1,4 @@
+src
+__tests__
+node_modules
+*.log

--- a/packages/babel-plugin-transform-hoist-loose-functions/README.md
+++ b/packages/babel-plugin-transform-hoist-loose-functions/README.md
@@ -1,0 +1,62 @@
+# babel-plugin-transform-hoist-loose-functions
+
+This plugin hoists functions in loose-mode to their enclosing function or
+program scope.
+
+## Example
+
+**In**
+
+```javascript
+function foo() {
+  if (a) {
+    function bar() {}
+  }
+}
+```
+
+**Out**
+
+```javascript
+function foo() {
+  function bar() {}
+
+  if (a) {}
+}
+```
+
+## Installation
+
+```sh
+npm install babel-plugin-transform-hoist-loose-functions
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["transform-hoist-loost-functions"]
+}
+```
+
+### Via CLI
+
+```sh
+babel --plugins transform-hoist-loose-functions script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["transform-hoist-loose-functions"]
+});
+```
+
+### Options
+
+None

--- a/packages/babel-plugin-transform-hoist-loose-functions/__tests__/hoist-loose-functions-tests.js
+++ b/packages/babel-plugin-transform-hoist-loose-functions/__tests__/hoist-loose-functions-tests.js
@@ -1,0 +1,226 @@
+jest.autoMockOff();
+
+const thePlugin = require("../../../utils/test-transform")(
+  require("../src/index")
+);
+
+describe("hoist-loose-functions-plugin", () => {
+  describe("loose mode", () => {
+    thePlugin(
+      "should hoist functions in top-level if blocks",
+      `
+      if (a) {
+        function bar() {}
+      }
+    `,
+      `
+      function bar() {}
+      if (a) {}
+    `
+    );
+
+    thePlugin(
+      "should hoist nested functions in if blocks",
+      `
+      function foo(a) {
+        if (a) {
+          function bar() {}
+        }
+      }
+    `,
+      `
+      function foo(a) {
+        function bar() {}
+
+        if (a) {}
+      }
+    `
+    );
+
+    thePlugin(
+      "should hoist functions in top-level while blocks",
+      `
+      while (true) {
+        function foo() {}
+      }
+    `,
+      `
+      function foo() {}
+      while (true) {}
+    `
+    );
+
+    thePlugin(
+      "should hoist nested functions in while blocks",
+      `
+      function foo() {
+        while (true) {
+          function bar() {}
+        }
+      }
+    `,
+      `
+      function foo() {
+        function bar() {}
+
+        while (true) {}
+      }
+    `
+    );
+
+    thePlugin(
+      "should hoist functions in top-level do blocks",
+      `
+      do {
+        function foo() {}
+      } while (true);
+    `,
+      `
+      function foo() {}
+      do {} while (true);
+    `
+    );
+
+    thePlugin(
+      "should hoist nested functions in do blocks",
+      `
+      function foo() {
+        do {
+          function bar() {}
+        } while (true);
+      }
+    `,
+      `
+      function foo() {
+        function bar() {}
+
+        do {} while (true);
+      }
+    `
+    );
+
+    thePlugin(
+      "should hoist functions in top-level anonymous blocks",
+      `
+      var a = 0;
+      {
+        function foo() {}
+      }
+      var b = 1;
+    `,
+      `
+      function foo() {}
+      var a = 0;
+      {}
+      var b = 1;
+    `
+    );
+
+    thePlugin(
+      "should hoist nested functions in anonymous blocks",
+      `
+      function foo() {
+        var a = 0;
+        {
+          function bar() {}
+        }
+        var b = 1;
+      }
+    `,
+      `
+      function foo() {
+        function bar() {}
+
+        var a = 0;
+        {}
+        var b = 1;
+      }
+    `
+    );
+
+    thePlugin(
+      "should only hoist to nearest function",
+      `
+      function outer() {
+        function inner() {
+          if (a) {
+            function foo() {}
+          }
+        }
+      }
+    `,
+      `
+      function outer() {
+        function inner() {
+          function foo() {}
+
+          if (a) {}
+        }
+      }
+    `
+    );
+  });
+
+  describe("strict mode", () => {
+    thePlugin(
+      "should not hoist top-level if program is strict",
+      `
+      'use strict';
+
+      if (true) {
+        function foo() {}
+      }
+      `
+    );
+
+    thePlugin(
+      "should not hoist nested if program is strict",
+      `
+      'use strict';
+
+      function foo() {
+        if (true) {
+          function bar() {}
+        }
+      }
+      `
+    );
+
+    thePlugin(
+      "should not hoist nested if outer function is strict",
+      `
+      'use strict';
+
+      function foo() {
+        'use strict';
+
+        if (true) {
+          function bar() {}
+        }
+      }
+      `
+    );
+
+    thePlugin(
+      "should hoist strict function if outer function is loose",
+      `
+      function foo() {
+        if (true) {
+          function bar () {
+            'use strict';
+          }
+        }
+      }
+    `,
+      `
+      function foo() {
+        function bar() {
+          'use strict';
+        }
+
+        if (true) {}
+      }
+    `
+    );
+  });
+});

--- a/packages/babel-plugin-transform-hoist-loose-functions/package.json
+++ b/packages/babel-plugin-transform-hoist-loose-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "babel-plugin-transform-hoist-loose-functions",
+  "version": "0.2.0",
+  "description": "This plugin hoists function declarations in loose mode to the beginning of their enclosing function scope",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "homepage": "https://github.com/babel/minify#readme",
+  "bugs": "https://github.com/babel/minify/issues",
+  "license": "MIT",
+  "author": "rossipedia",
+  "main": "lib/index.js",
+  "repository": "https://github.com/babel/minify/tree/master/packages/babel-plugin-transform-hoist-loose-functions"
+}

--- a/packages/babel-plugin-transform-hoist-loose-functions/src/index.js
+++ b/packages/babel-plugin-transform-hoist-loose-functions/src/index.js
@@ -1,0 +1,73 @@
+"use strict";
+
+function hasStrictModeDirective(path) {
+  const { directives } = path.isProgram() ? path.node : path.node.body;
+  return directives.some(
+    d =>
+      d.value &&
+      d.value.type === "DirectiveLiteral" &&
+      d.value.value === "use strict"
+  );
+}
+
+function isStrictMode(path) {
+  while (path) {
+    if (hasStrictModeDirective(path)) {
+      return true;
+    }
+    path = path.getFunctionParent();
+  }
+  return false;
+}
+
+function isHoisted(path, parent) {
+  let children = parent.get("body");
+  if (parent.isFunctionDeclaration()) {
+    children = children.get("body");
+  }
+
+  for (const child of children) {
+    if (!child.isFunctionDeclaration()) return false;
+    if (child === path) return true;
+  }
+  return false;
+}
+
+function findFirstNonFn(path) {
+  let children = path.get("body");
+  if (path.isFunctionDeclaration()) {
+    children = children.get("body");
+  }
+
+  for (const child of children) {
+    if (!child.isFunctionDeclaration()) return child;
+  }
+  return null;
+}
+
+module.exports = function({ types: t }) {
+  return {
+    name: "transform-hoist-loose-functions",
+    visitor: {
+      FunctionDeclaration(path) {
+        const fn = path.getFunctionParent();
+        if (
+          (fn.isFunctionDeclaration() ||
+            fn.isFunctionExpression() ||
+            fn.isProgram()) &&
+          !isHoisted(path, fn) &&
+          !isStrictMode(fn)
+        ) {
+          const newFn = t.clone(path.node);
+          const firstNonFn = findFirstNonFn(fn);
+          if (firstNonFn) {
+            firstNonFn.insertBefore(newFn);
+          } else {
+            fn.get("body").pushContainer("body", newFn);
+          }
+          path.remove();
+        }
+      }
+    }
+  };
+};

--- a/packages/babel-preset-minify/README.md
+++ b/packages/babel-preset-minify/README.md
@@ -76,6 +76,7 @@ deadcode            | [minify-dead-code-elimination][deadcode]                  
 evaluate            | [minify-constant-folding][evaluate]                            | true
 flipComparisons     | [minify-flip-comparisons][flipComparisons]                     | true
 guards              | [minify-guarded-expressions][guards]                           | true
+hoistFunctions      | [transform-hoist-loose-functions][hoistFunctions]              | false
 infinity            | [minify-infinity][infinity]                                    | true
 mangle              | [minify-mangle-names][mangle]                                  | true
 memberExpressions   | [transform-member-expression-literals][memberExpressions]      | true
@@ -149,6 +150,7 @@ tdz                 | Passed to [builtIns][builtIns], [evaluate][evaluate], [dea
 [evaluate]: ../../packages/babel-plugin-minify-constant-folding
 [flipComparisons]: ../../packages/babel-plugin-minify-flip-comparisons
 [guards]: ../../packages/babel-plugin-minify-guarded-expressions
+[hoistFunctions]: ../../packages/babel-plugin-transform-hoist-loose-functions
 [infinity]: ../../packages/babel-plugin-minify-infinity
 [mangle]: ../../packages/babel-plugin-minify-mangle-names
 [memberExpressions]: ../../packages/babel-plugin-transform-member-expression-literals

--- a/packages/babel-preset-minify/__tests__/options-tests.js
+++ b/packages/babel-preset-minify/__tests__/options-tests.js
@@ -22,7 +22,8 @@ const mocks = [
   "babel-plugin-transform-remove-debugger",
   "babel-plugin-transform-remove-undefined",
   "babel-plugin-transform-simplify-comparison-operators",
-  "babel-plugin-transform-undefined-to-void"
+  "babel-plugin-transform-undefined-to-void",
+  "babel-plugin-transform-hoist-loose-functions"
 ];
 
 mocks.forEach(mockName => {

--- a/packages/babel-preset-minify/package.json
+++ b/packages/babel-preset-minify/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-minify-replace": "^0.2.0",
     "babel-plugin-minify-simplify": "^0.2.0",
     "babel-plugin-minify-type-constructors": "^0.2.0",
+    "babel-plugin-transform-hoist-loose-functions": "^0.2.0",
     "babel-plugin-transform-inline-consecutive-adds": "^0.2.0",
     "babel-plugin-transform-member-expression-literals": "^6.8.5",
     "babel-plugin-transform-merge-sibling-variables": "^6.8.6",

--- a/packages/babel-preset-minify/src/index.js
+++ b/packages/babel-preset-minify/src/index.js
@@ -14,6 +14,7 @@ const PLUGINS = [
   ["evaluate",            require("babel-plugin-minify-constant-folding"),                 true],
   ["flipComparisons",     require("babel-plugin-minify-flip-comparisons"),                 true],
   ["guards",              require("babel-plugin-minify-guarded-expressions"),              true],
+  ["hoistFunctions",      require("babel-plugin-transform-hoist-loose-functions"),         false],
   ["infinity",            require("babel-plugin-minify-infinity"),                         true],
   ["mangle",              require("babel-plugin-minify-mangle-names"),                     true],
   ["memberExpressions",   require("babel-plugin-transform-member-expression-literals"),    true],


### PR DESCRIPTION
fixes #682

This is my first attempt at a babel plugin (please be gentle 🙂), and this is probably nowhere near the correct way of doing things, but it _seems_ to work (tests included, and existing tests are green). I'm not entirely familiar with the babel API, so there's probably quite a bit of room for improvement. Feedback welcome!

Issues:

* Breaks a bunch of tests if enabled by default, due to issues with `preset-es2015`. IMO this should be opt-in _only_ if you are _not_ using babel to transform ES2015+, as I believe the `transform-es2015-block-scoping` plugin makes this unnecessary.