### PR TITLE
Request for publishing babel-plugin-transform-inline-variables

### DIFF
--- a/packages/babel-plugin-transform-inline-environment-variables/package.json
+++ b/packages/babel-plugin-transform-inline-environment-variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-inline-environment-variables",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Inline environment variables.",
   "keywords": [
     "babel-plugin"


### PR DESCRIPTION
Hello,

The ability to blacklist environment variables for our build is something we would like to use in production as soon as possible (without maintaining our own fork). I noticed this went in a while ago, and was hoping it was possible to have this change published.

Thanks.