### PR TITLE
Add test for multiple var statements

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -406,6 +406,28 @@ describe("dce-plugin", () => {
   );
 
   thePlugin(
+    "should not inline vars modified in different var statements - issue #685",
+    `
+    function f() {
+      var a = 1;
+      var b = a;
+      var a = 2;
+      console.log(a, b);
+    }
+    f();
+  `,
+    `
+    function f() {
+      var a = 1;
+      var b = a;
+      var a = 2;
+      console.log(a, b);
+    }
+    f();
+  `
+  );
+
+  thePlugin(
     "should remove redundant returns",
     `
     function foo() {


### PR DESCRIPTION
Adds a (currently failing) test for #685.

The failure is due to Babel (https://github.com/babel/babel/issues/6217), and passes when a patched Babel (such as https://github.com/babel/babel/pull/6219/) is used.