### PR TITLE
fix(dce): extract only binding identifiers during block removal

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -2516,4 +2516,17 @@ describe("dce-plugin", () => {
       }
     `
   );
+
+  thePlugin(
+    "extractVars should extract only identifiers & ignore ObjectPattern/ArrayPattern",
+    `
+      if (false) {
+        var {x, y} = foo();
+        var [a, b] = bar();
+      }
+    `,
+    `
+      var x, y, a, b;
+    `
+  );
 });

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -948,7 +948,11 @@ module.exports = ({ types: t, traverse }) => {
 
     if (path.isVariableDeclaration({ kind: "var" })) {
       for (const decl of path.node.declarations) {
-        declarators.push(t.variableDeclarator(decl.id));
+        const bindingIds = Object.keys(t.getBindingIdentifiers(decl.id));
+
+        declarators.push(
+          ...bindingIds.map(name => t.variableDeclarator(t.identifier(name)))
+        );
       }
     } else {
       path.traverse({
@@ -957,7 +961,12 @@ module.exports = ({ types: t, traverse }) => {
           if (!isSameFunctionScope(varPath, path)) return;
 
           for (const decl of varPath.node.declarations) {
-            declarators.push(t.variableDeclarator(decl.id));
+            const bindingIds = Object.keys(t.getBindingIdentifiers(decl.id));
+            declarators.push(
+              ...bindingIds.map(name =>
+                t.variableDeclarator(t.identifier(name))
+              )
+            );
           }
         }
       });


### PR DESCRIPTION
+ Fix #710