### PR TITLE
Specify *.jar as binary in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 * text eol=lf
+*.jar binary


### PR DESCRIPTION
scripts/gcc.jar always showed up as being modified, because git was
replacing the newlines in this binary file.