### PR TITLE
Fix for dead code elimination trying to place an expression into a JSXIdentifier.

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -200,4 +200,25 @@ describe("dce-plugin", () => {
       plugins: [[deadcode, { tdz: true }]]
     }
   );
+
+  thePlugin(`should not inline into JSXIdentifiers`,
+      `
+    function foo(obj) {
+      var Element = obj || "";
+
+      return <Element />;
+    }
+  `,
+    `
+    function foo(obj) {
+      var Element = obj || "";
+
+      return <Element />;
+    }
+  `,
+    {
+      parserOpts: { plugins:["jsx"] },
+      plugins: [deadcode]
+    }
+  )
 });

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -294,11 +294,15 @@ module.exports = ({ types: t, traverse }) => {
               binding.kind !== "module" &&
               binding.constant
             ) {
+              const refPath = binding.referencePaths[0];
+
+              // JSXIdentifiers can't be replaced with arbitrary expressions.
+              if (refPath.isJSXIdentifier())
+                continue;
+
               let replacement = binding.path.node;
               let replacementPath = binding.path;
               let isReferencedBefore = false;
-
-              const refPath = binding.referencePaths[0];
 
               if (t.isVariableDeclarator(replacement)) {
                 const _prevSiblings = prevSiblings(replacementPath);


### PR DESCRIPTION
Fix for dead code elimination trying to place an expression into a JSXIdentifier. Closes #724.