### PR TITLE
fix: property names minification - removal of quotes

### DIFF
--- a/packages/babel-plugin-minify-constant-folding/src/index.js
+++ b/packages/babel-plugin-minify-constant-folding/src/index.js
@@ -160,6 +160,15 @@ module.exports = babel => {
             }
           }
 
+          // this will convert object to object but
+          // t.valueToNode has other effects where property name
+          // is not treated for the respective environment.
+          // So we bail here for objects and let other plugins
+          // take care of converting String literal to Identifier
+          if (typeof res.value === "object") {
+            return;
+          }
+
           const node = t.valueToNode(res.value);
           node[seen] = true;
           path.replaceWith(node);

--- a/packages/babel-preset-minify/__tests__/preset-tests.js
+++ b/packages/babel-preset-minify/__tests__/preset-tests.js
@@ -142,4 +142,15 @@ describe("preset", () => {
     })();
   `
   );
+
+  thePlugin(
+    "should fix unicode",
+    `
+      function foo() {
+        module.exports = {
+          "\uD835\uDCB6": "ascr"
+        };
+      }
+    `
+  );
 });


### PR DESCRIPTION
+ t.valueToNode(<objectExpressionNode>) returns an object expression
node and again but with a few other effects - it removes the quotes from
property names for some unicode which is not supported in Safari and a
few other older browsers. So we bail here and let propertyLiterals
plugin handle the conversion of StringLiterals to Identifiers.
+ Fix #627
+ Fix #706
