### PR TITLE
[WIP] Ignoring values after return statement in SwitchCase

### DIFF
--- a/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
+++ b/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
@@ -1624,6 +1624,66 @@ describe("simplify-plugin", () => {
   );
 
   thePlugin(
+    "should ignore statements after return",
+    `
+    function bar(foo) {
+      switch (foo) {
+        case 'foo':
+          console.log('foo')
+          return 1;
+          console.log('bar')
+        case 'bar':
+          return 2;
+        default:
+          return 3;
+      }
+    }
+    `,
+    `
+    function bar(foo) {
+      return foo === 'foo' ? (console.log('foo'), 1) : foo === 'bar' ? 2 : 3;
+    }
+    `
+  );
+
+  thePlugin(
+    "should deoptimize if statement could not be converted to sequenceExpression",
+    `
+    function bar(foo) {
+      switch (foo) {
+        case 'foo':
+          var something = foo();
+          console.log('foo');
+          return 1;
+          console.log('ignore');
+
+        case 'bar':
+          return 2;
+        default:
+          return 3;
+      }
+    }
+    `,
+    `
+    function bar(foo) {
+      switch (foo) {
+        case 'foo':
+          var something = foo();
+
+          return console.log('foo'), 1;
+          console.log('ignore');
+
+
+        case 'bar':
+          return 2;
+        default:
+          return 3;
+      }
+    }
+    `
+  );
+
+  thePlugin(
     "should convert switch statements with next return as default to returns",
     `
     function bar() {

--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -687,7 +687,7 @@ module.exports = ({ types: t }) => {
             let defaultRet;
             for (const switchCase of node.cases) {
               if (switchCase.consequent.length > 1) {
-                return;
+                if (!t.isReturnStatement(switchCase.consequent[0])) return;
               }
 
               const cons = switchCase.consequent[0];


### PR DESCRIPTION
> Done as part of [Goodness Squad Meetup](https://www.meetup.com/Kyiv-ReactJS-Meetup/events/242948507/)

Minor optimization that allows to cut ignored by interpreter values after`return` statement.

cc @yavorsky 