### PR TITLE
fix(dce): don't remove toplevel classes

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/toplevel-class/actual.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/toplevel-class/actual.js
@@ -1,0 +1,1 @@
+class Foo {}

--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/toplevel-class/expected.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/toplevel-class/expected.js
@@ -1,0 +1,1 @@
+class Foo {}

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -208,6 +208,14 @@ module.exports = ({ types: t, traverse }) => {
             ) {
               // `bar(function foo() {})` foo is not referenced but it's used.
               continue;
+            } else if (
+              // ClassDeclaration has binding in two scopes
+              //   1. The scope in which it is declared
+              //   2. The class's own scope
+              binding.path.isClassDeclaration() &&
+              binding.path === scope.path
+            ) {
+              continue;
             }
 
             const mutations = [];


### PR DESCRIPTION
Apply the same trick we use in mangler to detect toplevel classes

+ Fix #741 