### PR TITLE
fix(dce): bail on non-constant replacement path

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/actual.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/actual.js
@@ -1,0 +1,9 @@
+function loop() {
+  var end = 0;
+  var start = end;
+  while (end < 10) {
+    console.log(start, end);
+    var end = end + 1;
+  }
+}
+loop();

--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/actual.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/actual.js
@@ -7,3 +7,10 @@ function loop() {
   }
 }
 loop();
+
+function bar() {
+  var x = 1;
+  var y = x + 2;
+  var x = 3;
+  return x + y;
+}

--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/expected.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/expected.js
@@ -1,0 +1,9 @@
+function loop() {
+  var end = 0;
+  var start = end;
+  while (end < 10) {
+    console.log(start, end);
+    var end = end + 1;
+  }
+}
+loop();

--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/expected.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/fixtures/issue-685/expected.js
@@ -7,3 +7,10 @@ function loop() {
   }
 }
 loop();
+
+function bar() {
+  var x = 1;
+  var y = x + 2;
+  var x = 3;
+  return x + y;
+}

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -355,6 +355,7 @@ module.exports = ({ types: t, traverse }) => {
                 // ensure that the duplication of replacement is not affected
                 // https://github.com/babel/minify/issues/685
                 bail = !(
+                  binding &&
                   refPath.scope.getBinding(replacement.name) === binding &&
                   binding.constantViolations.length === 0
                 );
@@ -369,10 +370,12 @@ module.exports = ({ types: t, traverse }) => {
                       return;
                     }
                     const binding = scope.getBinding(node.name);
-                    bail = !(
-                      refPath.scope.getBinding(node.name) === binding ||
-                      binding.constantViolations.length === 0
-                    );
+                    if (
+                      binding &&
+                      refPath.scope.getBinding(node.name) === binding
+                    ) {
+                      bail = binding.constantViolations.length > 0;
+                    }
                   }
                 });
               }


### PR DESCRIPTION
In one use variable replacement, if the right hand side contains
constant violations, the left-hand side is supposed to be preserved, so
we detect this and bail out for this case

+ Fix #685