### PR TITLE
babel 7 compatibility change - mangle names: 

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/src/fixup-var-scoping.js
+++ b/packages/babel-plugin-minify-mangle-names/src/fixup-var-scoping.js
@@ -7,7 +7,7 @@ module.exports = function(mangler) {
       if (path.node.kind !== "var") {
         return;
       }
-      const fnScope = path.scope.getFunctionParent();
+      const fnScope = path.scope.getFunctionParent() || path.scope.getProgramParent();
       const bindingIds = path.getOuterBindingIdentifierPaths();
 
       for (const name in bindingIds) {

--- a/packages/babel-plugin-minify-mangle-names/src/fixup-var-scoping.js
+++ b/packages/babel-plugin-minify-mangle-names/src/fixup-var-scoping.js
@@ -7,7 +7,8 @@ module.exports = function(mangler) {
       if (path.node.kind !== "var") {
         return;
       }
-      const fnScope = path.scope.getFunctionParent() || path.scope.getProgramParent();
+      const fnScope =
+        path.scope.getFunctionParent() || path.scope.getProgramParent();
       const bindingIds = path.getOuterBindingIdentifierPaths();
 
       for (const name in bindingIds) {


### PR DESCRIPTION
handle getFunctionParen not returning a Program

Due to [this](https://github.com/babel/babel/pull/5923) change, mangle-names does not work with Babel 7 without this update.
