### PR TITLE
fix(mangle) - mark the correct eval scope during mangling

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/__tests__/fixtures/issue-366/actual.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/fixtures/issue-366/actual.js
@@ -1,0 +1,4 @@
+function myEval(code, _var_) {
+  eval(code);
+}
+myEval("console.log(_var_)", "myValue");

--- a/packages/babel-plugin-minify-mangle-names/__tests__/fixtures/issue-366/expected.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/fixtures/issue-366/expected.js
@@ -1,0 +1,4 @@
+function myEval(code, _var_) {
+  eval(code);
+}
+myEval("console.log(_var_)", "myValue");

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -112,7 +112,8 @@ module.exports = babel => {
       /**
        * Same usage as in DCE, whichever runs first
        */
-      if (!isEvalScopesMarked(mangler.program.scope)) {
+
+      if (!isEvalScopesMarked(mangler.program)) {
         markEvalScopes(mangler.program);
       }
 


### PR DESCRIPTION
We were always checking the wrong scope that was marked by DCE in another pass. 

+ fixes #366 
+ fixes #605 