### PR TITLE
fix(simplify): remove redundant patterns

### DIFF
--- a/packages/babel-plugin-minify-simplify/src/conditional-expression.js
+++ b/packages/babel-plugin-minify-simplify/src/conditional-expression.js
@@ -13,25 +13,17 @@ module.exports = t => {
     const consequent = path.get("consequent");
     const alternate = path.get("alternate");
 
-    const { Expression: EX, LogicalExpression: LE } = h.typeSymbols(t);
+    const { Expression: EX } = h.typeSymbols(t);
 
     // Convention:
     // ===============
     // for each pattern [test, consequent, alternate, handler(expr, cons, alt)]
     const matcher = new PatternMatch([
-      [LE, true, false, e => e],
       [EX, true, false, e => notnot(e)],
-
       [EX, false, true, e => not(e)],
-
-      [LE, true, EX, (e, c, a) => or(e, a)],
       [EX, true, EX, (e, c, a) => or(notnot(e), a)],
-
       [EX, false, EX, (e, c, a) => and(not(e), a)],
-
       [EX, EX, true, (e, c) => or(not(e), c)],
-
-      [LE, EX, false, (e, c) => and(notnot(e), c)],
       [EX, EX, false, (e, c) => and(notnot(e), c)]
     ]);
 

--- a/packages/babel-preset-minify/__tests__/preset-tests.js
+++ b/packages/babel-preset-minify/__tests__/preset-tests.js
@@ -153,4 +153,21 @@ describe("preset", () => {
       }
     `
   );
+
+  thePlugin(
+    "should fix issue#769 simplify + deadcode",
+    `
+      function fn(foo) {
+        if (foo && foo.length > 5) {
+          return true;
+        }
+        return false;
+      }
+    `,
+    `
+      function fn(a) {
+        return !!(a && 5 < a.length);
+      }
+    `
+  );
 });


### PR DESCRIPTION
Expression and LogicalExpression handled separately causes the issues as
mentioned in the issue below. So we handle only Expressions and ignore
LogicalExpressions.

+ fix #769