### PR TITLE
(perf) - move the collapser check before inling properties

### DIFF
--- a/packages/babel-plugin-transform-inline-consecutive-adds/src/index.js
+++ b/packages/babel-plugin-transform-inline-consecutive-adds/src/index.js
@@ -149,11 +149,11 @@ function getReferenceChecker(references) {
 function tryUseCollapser(t, collapser, varDecl, topLevel, checkReference) {
   // Returns true iff successfully used the collapser. Otherwise returns undefined.
   const [name, init, startIndex] = topLevel;
-  const body = varDecl.parentPath.get("body");
   if (!collapser.isInitTypeValid(init)) {
     return;
   }
 
+  const body = varDecl.parentPath.get("body");
   const [statements, exprs] = getContiguousStatementsAndExpressions(
     body,
     startIndex + 1,


### PR DESCRIPTION
This yields us a huge **3.5x improvement** on a test file > 2MB. 
```
pluginAlias                       time(ms)

// Before
transform-inline-consecutive-adds - 5716.129
transform-inline-consecutive-adds - 5752.153
transform-inline-consecutive-adds - 5813.064

// After
transform-inline-consecutive-adds - 1624.955
transform-inline-consecutive-adds - 1925.298
transform-inline-consecutive-adds - 1788.473
```
Thanks to chrome devtools for helping to find the root cause. Confirmation from devtools

### Before

<img width="919" alt="screen shot 2017-12-29 at 22 16 38" src="https://user-images.githubusercontent.com/3902525/34447736-fae7506a-ece6-11e7-85d8-fab8e95c860c.png">


### After

<img width="911" alt="screen shot 2017-12-29 at 22 27 23" src="https://user-images.githubusercontent.com/3902525/34447788-78ca36f0-ece7-11e7-9170-c25dd100b8c8.png">

