### PR TITLE
(perf) - Improve performance of simplify by removing traversal

### DIFF
--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -490,16 +490,6 @@ module.exports = ({ types: t }) => {
           return;
         }
         node.body = statements;
-
-        // this additional traversal is horrible but it's done to fix
-        // https://github.com/babel/minify/issues/323
-        // in which type annotation somehow gets messed up
-        // during sequence expression transformation
-        path.traverse({
-          Identifier: function(path) {
-            path.getTypeAnnotation();
-          }
-        });
       },
 
       BlockStatement: {

--- a/packages/babel-plugin-transform-simplify-comparison-operators/src/index.js
+++ b/packages/babel-plugin-transform-simplify-comparison-operators/src/index.js
@@ -1,6 +1,67 @@
 "use strict";
 
-module.exports = function() {
+module.exports = function({ types: t }) {
+  // custom implementation of getTypeAnnotation that fixes
+  // the type information that is lost during sequence expression transformation
+  // https://github.com/babel/minify/issues/323
+  function customTypeAnnotation(path) {
+    if (path.typeAnnotation) {
+      return path.typeAnnotation;
+    }
+
+    // We are not handling the case of literals and other base types
+    // since they are already handled via getTypeAnnotation
+    const { node } = path;
+    const binding = path.parentPath.scope.getBinding(node.name);
+
+    const types = [];
+    if (binding && binding.constantViolations) {
+      if (binding.identifier.typeAnnotation) {
+        return binding.identifier.typeAnnotation;
+      }
+      if (binding.constantViolations) {
+        const violations = binding.constantViolations;
+        for (let violation of violations) {
+          types.push(violation.getTypeAnnotation());
+        }
+      }
+    }
+
+    if (types.length > 0) {
+      return t.createUnionTypeAnnotation(types);
+    }
+    return types;
+  }
+
+  // Based on the type inference in Babel
+  function baseTypeStrictlyMatches(left, right) {
+    let leftTypes, rightTypes;
+
+    if (t.isIdentifier(left)) {
+      leftTypes = customTypeAnnotation(left);
+    } else if (t.isIdentifier(right)) {
+      rightTypes = customTypeAnnotation(right);
+    }
+
+    // Early exit
+    if (t.isAnyTypeAnnotation(leftTypes) || t.isAnyTypeAnnotation(rightTypes)) {
+      return false;
+    }
+
+    leftTypes = [].concat(leftTypes, left.getTypeAnnotation());
+    rightTypes = [].concat(rightTypes, right.getTypeAnnotation());
+
+    leftTypes = t.createUnionTypeAnnotation(leftTypes);
+    rightTypes = t.createUnionTypeAnnotation(rightTypes);
+
+    if (
+      !t.isAnyTypeAnnotation(leftTypes) &&
+      t.isFlowBaseAnnotation(leftTypes)
+    ) {
+      return leftTypes.type === rightTypes.type;
+    }
+  }
+
   return {
     name: "transform-simplify-comparison-operators",
     visitor: {
@@ -15,7 +76,8 @@ module.exports = function() {
 
         const left = path.get("left");
         const right = path.get("right");
-        const strictMatch = left.baseTypeStrictlyMatches(right);
+
+        const strictMatch = baseTypeStrictlyMatches(left, right);
         if (strictMatch) {
           node.operator = node.operator.slice(0, -1);
         }


### PR DESCRIPTION
This PR handles the type information that is lost due to sequence expression transformation in Simplify plugin. It takes a different approach instead of traversing all of the identifiers for type information. 

### Before

pluginAlias                             time(ms) # visits time/visit(ms)
// Run 1
minify-simplify                         6090.013 278330   0.022
transform-simplify-comparison-operators 41.059   18348    0.002
// Run 2
minify-simplify                         6029.847 278330   0.022
transform-simplify-comparison-operators 46.415   18348    0.003
// Run 3
minify-simplify                         6045.218 278330   0.022
transform-simplify-comparison-operators 44.464   18348    0.002

### After
// 1
minify-simplify                         4617.782 278330   0.017
transform-simplify-comparison-operators 122.181  18348    0.007
// 2
minify-simplify                         4718.766 278330   0.017
transform-simplify-comparison-operators 122.642  18348    0.007
// 3
minify-simplify                         4447.601 278330   0.016
transform-simplify-comparison-operators 127.682  18348    0.007

The type inference is based on the Babel inference. 

+ Only for identifiers we take the different path