### PR TITLE
Transform property literal reserved keywords as described in the docu…

### DIFF
--- a/packages/babel-plugin-transform-property-literals/__tests__/fixtures/invalid-identifiers/actual.js
+++ b/packages/babel-plugin-transform-property-literals/__tests__/fixtures/invalid-identifiers/actual.js
@@ -1,7 +1,6 @@
-// FIXME: The test name states that no transformation should take place,
-// but the actual test specifies that the quotes should be stripped.
 //prettier-ignore
 ({
   "default": null,
-  "import": null
+  "import": null,
+  "foo": null
 });

--- a/packages/babel-plugin-transform-property-literals/__tests__/fixtures/invalid-identifiers/expected.js
+++ b/packages/babel-plugin-transform-property-literals/__tests__/fixtures/invalid-identifiers/expected.js
@@ -1,7 +1,6 @@
-// FIXME: The test name states that no transformation should take place,
-// but the actual test specifies that the quotes should be stripped.
 //prettier-ignore
 ({
-  default: null,
-  import: null
+  "default": null,
+  "import": null,
+  foo: null
 });

--- a/packages/babel-plugin-transform-property-literals/src/property-name.js
+++ b/packages/babel-plugin-transform-property-literals/src/property-name.js
@@ -34,6 +34,9 @@ limitations under the License.
 
  */
 function reduceStaticPropertyNameES5(t, node) {
+  if (keyword.isReservedWordES5(node.value)) {  
+    return t.Identifier(escapeStringLiteral(node.value));
+  }
   if (keyword.isIdentifierNameES5(node.value)) {
     return t.Identifier(node.value);
   }


### PR DESCRIPTION
…mentation.

The documentation describes that when using babel-plugin-transform-property-literals, reserved keywords used as identifiers should have quotes around them, however this does not happen. There are FIXME mentions in the test files, but this is not mentioned in the documentation. Hence I've fixed the code and tests to align with the documentation