### PR TITLE
chore(eslint): mark as root config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 const OFF = "off";
 
 module.exports = {
+  root: true,
   extends: "eslint:recommended",
   parserOptions: {
     ecmaVersion: 2017,


### PR DESCRIPTION
This [marks the file as the root config](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy) to prevent ESLint from looking for config files in parent directories.