### PR TITLE
fix: Remove unnecessary checks for constant folding

### DIFF
--- a/packages/babel-plugin-minify-constant-folding/src/index.js
+++ b/packages/babel-plugin-minify-constant-folding/src/index.js
@@ -116,10 +116,6 @@ module.exports = babel => {
           return;
         }
 
-        // if (traverse.hasType(node, "Identifier", t.FUNCTION_TYPES)) {
-        //   return;
-        // }
-
         // -0 maybe compared via dividing and then checking against -Infinity
         // Also -X will always be -X.
         if (

--- a/packages/babel-plugin-minify-constant-folding/src/index.js
+++ b/packages/babel-plugin-minify-constant-folding/src/index.js
@@ -116,11 +116,9 @@ module.exports = babel => {
           return;
         }
 
-        if (
-          traverse.hasType(node, path.scope, "Identifier", t.FUNCTION_TYPES)
-        ) {
-          return;
-        }
+        // if (traverse.hasType(node, "Identifier", t.FUNCTION_TYPES)) {
+        //   return;
+        // }
 
         // -0 maybe compared via dividing and then checking against -Infinity
         // Also -X will always be -X.


### PR DESCRIPTION
We found that `traverse.hasType` introduces a lot of side-effects since its create cache entries for path where scope might not be defined.

If this method is called for a path that has never been created, it will bound the wrong scope object to it, causing subsequent access to throw.

For example this exception:
```
TypeError: Cannot read property 'getBinding' of null
```
can be traced down to this exact problem.
FYI this is the exact same failure we have on the CI.
