### PR TITLE
Add member access constant folding

### DIFF
--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-builtin/actual.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-builtin/actual.js
@@ -1,0 +1,16 @@
+({
+  toString: () => 'bar',
+  [computed]: 'foo'
+}).toString;
+({
+  [computed]: 'foo',
+  toString: () => 'bar'
+}).toString;
+({
+  [computed]: 'foo'
+}).toString;
+({
+  toString: () => 'bar'
+}).toString;
+({}).toString;
+({}).notBuiltIn;

--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-builtin/expected.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-builtin/expected.js
@@ -1,0 +1,15 @@
+({
+  toString: () => 'bar',
+  [computed]: 'foo'
+}).toString;
+
+() => 'bar';
+
+({
+  [computed]: 'foo'
+}).toString;
+
+() => 'bar';
+
+({}).toString;
+void 0;

--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-computed/actual.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-computed/actual.js
@@ -1,0 +1,32 @@
+({
+  ['foo']: 'oof',
+  bar: 'rab'
+}).foo;
+({
+  ['foo']: 'oof',
+  bar: 'rab'
+}).baz;
+({
+  foo: 'bar',
+  [computed]: 'foo'
+}).foo;
+({
+  [computed]: 'foo',
+  foo: 'bar'
+}).foo;
+({
+  [0]: 'foo',
+  ['foo']: 'bar'
+})[0];
+({
+  0: 'foo',
+  [computed]: 'val'
+})[0];
+({
+  [computed]: 'val',
+  [0]: 'foo'
+})[0];
+({
+  [computed]: 'val',
+  foo: 'bar'
+})[0];

--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-computed/expected.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access-computed/expected.js
@@ -1,0 +1,17 @@
+'oof';
+void 0;
+({
+  foo: 'bar',
+  [computed]: 'foo'
+}).foo;
+'bar';
+'foo';
+({
+  0: 'foo',
+  [computed]: 'val'
+})[0];
+'foo';
+({
+  [computed]: 'val',
+  foo: 'bar'
+})[0];

--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access/actual.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access/actual.js
@@ -1,0 +1,27 @@
+({
+  foo: 'oof',
+  bar: 'rab'
+}).foo;
+({
+  bar: 'rab'
+}).foo;
+({
+  bar: 'rab'
+}).toString;
+({
+  foo,
+  bar: 'test',
+  baz
+}).foo;
+({
+  bar: 'test',
+  baz
+}).foo;
+({
+  0: 'foo',
+  1: 'bar',
+  b: 'az'
+})[0];
+({
+  foo: 'bar'
+})[0];

--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access/expected.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/member-access/expected.js
@@ -1,0 +1,7 @@
+'oof';
+void 0;
+({}).toString;
+foo;
+void 0;
+'foo';
+void 0;

--- a/packages/babel-plugin-minify-constant-folding/src/replacements.js
+++ b/packages/babel-plugin-minify-constant-folding/src/replacements.js
@@ -38,11 +38,10 @@ module.exports = ({ types: t }) => {
           if (hasSpread(this.node)) {
             return;
           }
-          if(this.node.properties.length === 0) {
-            if(key in EMPTY_OBJECT) {
-              return
-            }
-            else {
+          if (this.node.properties.length === 0) {
+            if (key in EMPTY_OBJECT) {
+              return;
+            } else {
               return undef;
             }
           }


### PR DESCRIPTION
Simplifies member access when it's safe (where `!($key in {})` and defined after any spread or computed property).

In : 
```js
const foo = {b: 'ar'}.b
```

Out : 
```js
const foo = 'ar'
```

- [x] bailout on computed properties or object spread
- [x] shorthand properties (`{foo}.foo` => `foo`)
- [x] numeric literals (`{0:'foo'}[0]` => `'foo'`)

Sorry for the after-review commits, just noticed it lacked numeric literals support