### PR TITLE
Allow options for plugins disabled by default (babel-preset-minify)

### DIFF
--- a/packages/babel-preset-minify/src/index.js
+++ b/packages/babel-preset-minify/src/index.js
@@ -66,6 +66,8 @@ function preset(context, _opts = {}) {
   // handle plugins and their options
   for (const [name] of PLUGINS) {
     if (isPlainObject(opts[name])) {
+      // for plugins disabled by default
+      pluginsMap[name].enabled = true;
       pluginsMap[name].options = opts[name];
     } else if (opts[name] !== void 0) {
       pluginsMap[name].enabled = !!opts[name];


### PR DESCRIPTION
Within babel-preset-minify, if you pass an options object for one of the plugins that is disabled by default (like removeConsole) it does not get enabled.

This PR fixes that, just ensuring any plugin you are setting options for is also enabled.