### PR TITLE
fix(const-folding): do not evaluate identifier in export specifiers

### DIFF
--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/export-specifier/actual.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/export-specifier/actual.js
@@ -1,0 +1,3 @@
+const a = "a";
+const b = "b";
+export { a, b };

--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/export-specifier/babel.json
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/export-specifier/babel.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/export-specifier/expected.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/fixtures/export-specifier/expected.js
@@ -1,0 +1,3 @@
+const a = "a";
+const b = "b";
+export { a, b };

--- a/packages/babel-plugin-minify-constant-folding/src/index.js
+++ b/packages/babel-plugin-minify-constant-folding/src/index.js
@@ -102,7 +102,7 @@ module.exports = babel => {
 
       // TODO: look into evaluating binding too (could result in more code, but gzip?)
       Expression(path, { opts: { tdz = false } = {} }) {
-        const { node } = path;
+        const { node, parent } = path;
 
         if (node[seen]) {
           return;
@@ -113,6 +113,11 @@ module.exports = babel => {
         }
 
         if (!path.isPure()) {
+          return;
+        }
+
+        // Avoid replacing the values for identifiers in exports
+        if (t.isExportSpecifier(parent)) {
           return;
         }
 


### PR DESCRIPTION
+ fix #820 