### PR TITLE
fix(mangle): handle inferred names for functions

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -149,8 +149,6 @@ module.exports = babel => {
          * - https://github.com/babel/minify/issues/829
          */
         BindingIdentifier(path) {
-          const { scope } = path;
-
           if (
             // the parent has this id as the name
             (path.parentPath.isFunctionExpression({ id: path.node }) ||

--- a/packages/babel-preset-minify/__tests__/minify-env-tests.js
+++ b/packages/babel-preset-minify/__tests__/minify-env-tests.js
@@ -237,7 +237,7 @@ describe("preset along with env", () => {
       }
     `,
     `
-      function _classCallCheck(a, b) { if (!(a instanceof b)) throw new TypeError(\"Cannot call a class as a function\"); }
+      function _classCallCheck(a, b) { if (!(a instanceof b)) throw new TypeError("Cannot call a class as a function"); }
 
       function bar() {
         var c = console;

--- a/packages/babel-preset-minify/__tests__/minify-env-tests.js
+++ b/packages/babel-preset-minify/__tests__/minify-env-tests.js
@@ -196,4 +196,59 @@ describe("preset along with env", () => {
       console.log(foo);
     `
   );
+
+  thePlugin(
+    "should fix issue#829 mangling after function name",
+    `
+      function foo() {
+        let con = console;
+
+        return {
+          a(bar) {
+            con.log(bar);
+          }
+        };
+      }
+    `,
+    `
+      function foo() {
+        var b = console;
+        return {
+          a: function d(c) {
+            b.log(c);
+          }
+        };
+      }
+    `
+  );
+
+  thePlugin(
+    "should fix issue#829 mangling after function name 2",
+    `
+      function bar() {
+        var b = console;
+        return {
+          a: class {
+            constructor(bar) {
+              b.log(bar);
+            }
+          }
+        };
+      }
+    `,
+    `
+      function _classCallCheck(a, b) { if (!(a instanceof b)) throw new TypeError(\"Cannot call a class as a function\"); }
+
+      function bar() {
+        var c = console;
+        return {
+          a: function b(a) {
+            "use strict";
+
+            _classCallCheck(this, b), c.log(a);
+          }
+        };
+      }
+    `
+  );
 });


### PR DESCRIPTION
The t.NOT_LOCAL_BINDING symbol used in plugin-function-name
(https://github.com/babel/babel/blob/bd98041321c60737ddcacd1ad7e056ef6de31879/packages/babel-helper-function-name/src/index.js#L206)
is causing this issue.

This was added in babel/babel#3298

The problem is the binding identifier is NOT registered (skipped) during
crawl and the mangler finds the first safe identifier which ultimately
collides with this name during runtime.

So, we register the binding and don't respect the t.NOT_LOCAL_BINDING.

Fix #829