### PR TITLE
perf: use deque for bfs traversal in mangler

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/package.json
+++ b/packages/babel-plugin-minify-mangle-names/package.json
@@ -12,6 +12,7 @@
   "main": "lib/index.js",
   "repository": "https://github.com/babel/minify/tree/master/packages/babel-plugin-minify-mangle-names",
   "dependencies": {
-    "babel-helper-mark-eval-scopes": "^0.4.3"
+    "babel-helper-mark-eval-scopes": "^0.4.3",
+    "denque": "^1.2.3"
   }
 }

--- a/packages/babel-plugin-minify-mangle-names/src/bfs-traverse.js
+++ b/packages/babel-plugin-minify-mangle-names/src/bfs-traverse.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const Denque = require("denque");
+
 module.exports = function bfsTraverseCreator({ types: t, traverse }) {
   function getFields(path) {
     return t.VISITOR_KEYS[path.type];
@@ -11,7 +13,7 @@ module.exports = function bfsTraverseCreator({ types: t, traverse }) {
     }
     const visitor = traverse.explode(_visitor);
 
-    const queue = [path];
+    const queue = new Denque([path]);
     let current;
 
     while (queue.length > 0) {

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -364,7 +364,7 @@ module.exports = babel => {
      */
     renameBindingIds(path, oldName, newName, predicate = () => true) {
       const bindingIds = path.getBindingIdentifierPaths(true, false);
-      for (const name in bindingIds) {
+      for (const name of Object.keys(bindingIds)) {
         if (name !== oldName) continue;
         for (const idPath of bindingIds[name]) {
           if (predicate(idPath)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,6 +1958,10 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+denque@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.2.3.tgz#98c50c8dd8cdfae318cc5859cc8ee3da0f9b0cc2"
+
 detect-file@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"


### PR DESCRIPTION
**Update**: No performance gains observed. Tested on node 9.10. 