### PR TITLE
Add missing scopes when adding reference to scope tracker

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/src/scope-tracker.js
+++ b/packages/babel-plugin-minify-mangle-names/src/scope-tracker.js
@@ -39,6 +39,7 @@ module.exports = class ScopeTracker {
   addReference(scope, binding, name) {
     let parent = scope;
     do {
+      this.addScope(parent);
       this.references.get(parent).add(name);
       if (!binding) {
         throw new Error(


### PR DESCRIPTION
Fixes "Cannot read property 'add' of undefined" error. #792 #556