### PR TITLE
chore: Don't do shallow clones on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 git:
-  depth: 10
+  depth: false
   submodules: false
 sudo: false
 language: node_js
 cache: yarn
-
 node_js:
   - "10"
   - "8"


### PR DESCRIPTION
Lerna canary doesn't work correctly with shallow clones.

From https://github.com/lerna/lerna/issues/1583#issuecomment-424596666.

@boopathi I can also incorporate #906 if you decide on it.

From #900 

> So, basically, once this PR is merged and you guys publish all the packages, the license issues will be fixed.

You haven't published all the packages. Only the packages which got changed, got published. Which means, the licensing issues still exist for older packages. Can you do a `lerna publish --force-publish` to fix this? (A new patch version should be good enough). Very important for us.