### PR TITLE
Clarifying use of Node API

### DIFF
--- a/packages/babel-preset-minify/README.md
+++ b/packages/babel-preset-minify/README.md
@@ -49,7 +49,12 @@ babel script.js --presets minify
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+const babel = require("@babel/core");
+const fs = require("fs");
+
+const code = fs.readFileSync("./input.js").toString();
+
+const minified = babel.transform(code, {
   presets: ["minify"]
 });
 ```


### PR DESCRIPTION
Making it obvious that the first argument to `.transform()` is a code string and that the return value is minified code.