### PR TITLE
chore(minify): remediate CVE-2018-3721: update lodash to latest, remove use of deprecated module packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ coverage
 lib/
 *.log
 *~
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 lib/
 *.log
 *~
+.idea/

--- a/packages/babel-minify/__tests__/__snapshots__/cli-tests.js.snap
+++ b/packages/babel-minify/__tests__/__snapshots__/cli-tests.js.snap
@@ -17,13 +17,13 @@ exports[`babel-minify CLI should handle comments 1`] = `
 Array [
   Object {
     "stderr": "",
-    "stdout": "import Foo from\\"foo\\";import pick from\\"lodash.pick\\";export const items=pick(Foo.all,[\\"a\\",\\"b\\",\\"c\\"]);export default Foo(items);",
+    "stdout": "import Foo from\\"foo\\";import pick from\\"lodash/pick\\";export const items=pick(Foo.all,[\\"a\\",\\"b\\",\\"c\\"]);export default Foo(items);",
   },
   Object {
     "stderr": "",
     "stdout": "// comment 1
 import Foo from\\"foo\\";// comment 2
-import pick from\\"lodash.pick\\";export const items/* comment 3 */=pick(Foo.all,[// comment 4
+import pick from\\"lodash/pick\\";export const items/* comment 3 */=pick(Foo.all,[// comment 4
 \\"a\\",// comment 5
 \\"b\\",// comment 6
 \\"c\\"]);export default Foo(items);",

--- a/packages/babel-minify/__tests__/fixtures/module/mod.js
+++ b/packages/babel-minify/__tests__/fixtures/module/mod.js
@@ -2,7 +2,7 @@
 import Foo from "foo";
 
 // comment 2
-import pick from "lodash.pick";
+import pick from "lodash/pick";
 
 export const items /* comment 3 */ = pick(Foo.all, [
   // comment 4

--- a/packages/babel-minify/package.json
+++ b/packages/babel-minify/package.json
@@ -21,7 +21,7 @@
     "@babel/core": "^7.1.0",
     "babel-preset-minify": "^0.5.0",
     "fs-readdir-recursive": "^1.1.0",
-    "lodash.pick": "^4.4.0",
+    "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
     "util.promisify": "^1.0.0",
     "yargs-parser": "^10.0.0"

--- a/packages/babel-minify/src/cli.js
+++ b/packages/babel-minify/src/cli.js
@@ -2,7 +2,7 @@ const yargsParser = require("yargs-parser");
 const optionsParser = require("./options-parser");
 const { version } = require("../package.json");
 const { handleStdin, handleFile, handleArgs, isFile } = require("./fs");
-const pick = require("lodash.pick");
+const pick = require("lodash/pick");
 
 const plugins = [
   "booleans",

--- a/packages/babel-plugin-minify-dead-code-elimination/package.json
+++ b/packages/babel-plugin-minify-dead-code-elimination/package.json
@@ -15,6 +15,6 @@
     "babel-helper-evaluate-path": "^0.5.0",
     "babel-helper-mark-eval-scopes": "^0.4.3",
     "babel-helper-remove-or-void": "^0.4.3",
-    "lodash.some": "^4.6.0"
+    "lodash": "^4.17.11"
   }
 }

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const some = require("lodash.some");
+const some = require("lodash/some");
 const { markEvalScopes, hasEval } = require("babel-helper-mark-eval-scopes");
 const removeUseStrict = require("./remove-use-strict");
 const evaluate = require("babel-helper-evaluate-path");

--- a/packages/babel-preset-minify/package.json
+++ b/packages/babel-preset-minify/package.json
@@ -36,6 +36,6 @@
     "babel-plugin-transform-remove-undefined": "^0.5.0",
     "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
     "babel-plugin-transform-undefined-to-void": "^6.9.4",
-    "lodash.isplainobject": "^4.0.6"
+    "lodash": "^4.17.11"
   }
 }

--- a/packages/babel-preset-minify/src/index.js
+++ b/packages/babel-preset-minify/src/index.js
@@ -1,4 +1,4 @@
-const isPlainObject = require("lodash.isplainobject");
+const isPlainObject = require("lodash/isPlainObject");
 
 // the flat plugin map
 // This is to prevent dynamic requires - require('babel-plugin-' + name);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5719,7 +5719,7 @@ lodash.isfunction@^3.0.8:
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz#4db709fc81bc4a8fd7127a458a5346c5cdce2c6b"
   integrity sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs=
 
-lodash.isplainobject@^4.0.4, lodash.isplainobject@^4.0.6:
+lodash.isplainobject@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
@@ -5733,16 +5733,6 @@ lodash.mapvalues@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
   integrity sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=
-
-lodash.pick@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
-lodash.some@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
-  integrity sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=
 
 lodash.sortby@^4.5.0, lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5769,7 +5759,7 @@ lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
 
-lodash@^4.17.10:
+lodash@^4.17.10, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
What:
Updated use of lodash to lodash/somefunc instead of lodash.somefunc:
* upgraded lodash deps to ^4.17.11
* updated requires from lodash.somefunc to lodash/somefunc
* updates snapshots

re-ran bootstrap, build and test

Why:
Updated to remediate CVE-2018-3721 - where modularized packages are specifically vulnerable, and as modularized packages are deprecated, no updates have been released in about 2 years.