### PR TITLE
babel-helper-evaluate-path is not listed as a dependency but is used as one.

### DIFF
--- a/packages/babel-plugin-minify-guarded-expressions/package.json
+++ b/packages/babel-plugin-minify-guarded-expressions/package.json
@@ -12,6 +12,7 @@
   "main": "lib/index.js",
   "repository": "https://github.com/babel/minify/tree/master/packages/babel-plugin-minify-guarded-expressions",
   "dependencies": {
+    "babel-helper-evaluate-path": "^0.5.0",
     "babel-helper-flip-expressions": "^0.4.3"
   }
 }


### PR DESCRIPTION
This causes an error to be thrown when using Yarn with pnp enabled.