### PR TITLE
Add missing `babel-helper-evaluate-path` dependency

### DIFF
--- a/packages/babel-plugin-minify-guarded-expressions/package.json
+++ b/packages/babel-plugin-minify-guarded-expressions/package.json
@@ -12,6 +12,7 @@
   "main": "lib/index.js",
   "repository": "https://github.com/babel/minify/tree/master/packages/babel-plugin-minify-guarded-expressions",
   "dependencies": {
+    "babel-helper-evaluate-path": "^0.5.0",
     "babel-helper-flip-expressions": "^0.4.3"
   }
 }


### PR DESCRIPTION
At the moment, the `babel-plugin-minify-guarded-expressions` package is calling `require('babel-helper-evaluate-path')` without actually depending on this package. It only works right now because of package hoisting.

An exception is thrown when npm does not flatten the dependency tree. You can trigger this to verify it by forcing npm to install packages without flattening (the npm@2 nested `node_modules` approach) by running: `npm install --legacy-bundling`