### PR TITLE
add missing babel-helper-evaluate-path pkg

### DIFF
--- a/packages/babel-plugin-minify-simplify/package.json
+++ b/packages/babel-plugin-minify-simplify/package.json
@@ -12,6 +12,7 @@
   "main": "lib/index.js",
   "repository": "https://github.com/babel/minify/tree/master/packages/babel-plugin-minify-simplify",
   "dependencies": {
+    "babel-helper-evaluate-path": "^0.5.0",
     "babel-helper-flip-expressions": "^0.4.3",
     "babel-helper-is-nodes-equiv": "^0.0.1",
     "babel-helper-to-multiple-sequence-expressions": "^0.5.0"


### PR DESCRIPTION
Fixes https://github.com/babel/minify/issues/884
Related to https://github.com/babel/minify/pull/963