### PR TITLE
fix: an error occurred if includes environment variable assignment expression

### DIFF
--- a/packages/babel-plugin-transform-inline-environment-variables/__tests__/inline-env-var-test.js
+++ b/packages/babel-plugin-transform-inline-environment-variables/__tests__/inline-env-var-test.js
@@ -24,6 +24,16 @@ describe("inline-env-plugin", () => {
   );
 
   thePlugin(
+    "should not inline environment variables if it is on left side of assigment expression",
+    `
+    process.env.NODE_ENV = "development";
+  `,
+    `
+    process.env.NODE_ENV = "development";
+  `
+  );
+
+  thePlugin(
     "should inline environment vars in computed forms",
     `
       process.env["NODE_ENV"]

--- a/packages/babel-plugin-transform-inline-environment-variables/src/index.js
+++ b/packages/babel-plugin-transform-inline-environment-variables/src/index.js
@@ -1,6 +1,11 @@
 "use strict";
 
 module.exports = function({ types: t }) {
+  function isLeftSideOfAssignmentExpression(path) {
+    return (
+      t.isAssignmentExpression(path.parent) && path.parent.left === path.node
+    );
+  }
   return {
     name: "transform-inline-environment-variables",
     visitor: {
@@ -9,6 +14,7 @@ module.exports = function({ types: t }) {
           const key = path.toComputedKey();
           if (
             t.isStringLiteral(key) &&
+            !isLeftSideOfAssignmentExpression(path) &&
             (!include || include.indexOf(key.value) !== -1) &&
             (!exclude || exclude.indexOf(key.value) === -1)
           ) {


### PR DESCRIPTION
The following code reproduce the bug:

```js
if(process.env.NODE_ENV !== "production"){
  process.env.NODE_ENV = "development"; // an error occurred
  // ...
}
```
```bash
babel --plugins transform-inline-environment-variables script.js
```
> TypeError: Property left of AssignmentExpression expected node to be of a type ["LVal"] but instead got "StringLiteral"