### PR TITLE
feat: Support variable name invariance

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -426,7 +426,7 @@ module.exports = ({ types: t, traverse }) => {
               const isReplacementObj =
                 isObj(replacement) || some(replacement, isObj);
 
-              if (!sharesRoot || (isReplacementObj && mayLoop)) {
+              if (this.keepVarName || !sharesRoot || (isReplacementObj && mayLoop)) {
                 continue;
               }
 
@@ -958,6 +958,7 @@ module.exports = ({ types: t, traverse }) => {
             opts: {
               // set defaults
               optimizeRawSize = false,
+              keepVarName = false,
               keepFnName = false,
               keepClassName = false,
               keepFnArgs = false,
@@ -974,6 +975,7 @@ module.exports = ({ types: t, traverse }) => {
           path.traverse(main, {
             functionToBindings: new Map(),
             optimizeRawSize,
+            keepVarName,
             keepFnName,
             keepClassName,
             keepFnArgs,


### PR DESCRIPTION
I need to keep the variable name，when I use javascript as the DSL like Vue mustache syntax that don't support `{{ key: 'value' }} `. So I need to transform into `{{varName}}`.
Hopefully, this feature will be supported.